### PR TITLE
Share memory in single session without user specification

### DIFF
--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -423,12 +423,8 @@ Status SessionState::PrepackConstantInitializedTensors(InlinedHashMap<std::strin
                 bool is_packed = false;
                 const Tensor& const_initialized_tensor = constant_initialized_tensors[ort_value_idx].Get<Tensor>();
 
-                auto iter = initializers_to_share_map.find(input_name);
-                bool is_shared_initializer = (iter != initializers_to_share_map.end());
-                is_shared_initializer = true; // Always try to share
-
                 // Caching pre-packed weights is limited to shared initializers associated with the CPU EP for now
-                if (is_shared_initializer && should_cache_prepacked_weights_for_shared_initializers &&
+                if (should_cache_prepacked_weights_for_shared_initializers &&
                     node.GetExecutionProviderType() == kCpuExecutionProvider) {  // caching of pre-packed weights' turned ON
 
                   AllocatorPtr allocator_for_caching = prepacked_weights_container_->GetOrCreateAllocator(CPU);

--- a/onnxruntime/core/framework/session_state.cc
+++ b/onnxruntime/core/framework/session_state.cc
@@ -425,6 +425,7 @@ Status SessionState::PrepackConstantInitializedTensors(InlinedHashMap<std::strin
 
                 auto iter = initializers_to_share_map.find(input_name);
                 bool is_shared_initializer = (iter != initializers_to_share_map.end());
+                is_shared_initializer = true; // Always try to share
 
                 // Caching pre-packed weights is limited to shared initializers associated with the CPU EP for now
                 if (is_shared_initializer && should_cache_prepacked_weights_for_shared_initializers &&


### PR DESCRIPTION
### Description
<!-- Describe your changes. -->
Removed is_shared_initializer from the decision to cache pre-packed weights. This allows memory to be shared within a single session even if the user does not specify it, thus reducing memory usage.

### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->
In the current implementation, memory is not shared even if the model shares parameters among multiple layers. There is a mechanism to share memory specified by the user, but the memory usage is large. By modifying the code slightly, we found that memory can be shared within a single session even if the user does not specify it, thus reducing memory usage.

In the current implementation, the decision to share or not to share memory is based on whether the memory is specified by the user or not. 

https://github.com/pfnet/onnxruntime/blob/5930e7e22fea92695b577731dd0ac2bc44afea26/onnxruntime/core/framework/session_state.cc#L426-L430

Even if this conditional branch is removed, memory that should not be shared will not be shared because there will be a conditional branch later in the Murmur hash to check whether the memory contents are the same or not.

https://github.com/pfnet/onnxruntime/blob/5930e7e22fea92695b577731dd0ac2bc44afea26/onnxruntime/core/framework/session_state.cc#L460-L465

